### PR TITLE
Remove special handling for empty container_map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@
 * Reintegrate the iptables-backend.
 * Make exposing containers via IPv6 configurable.
 * Ensure consistent behaviour regardless of whether `[global_defaults]` has been specified or not.
+* Don't exit DFW if there are no containers running ([#243], thanks to @Georgiy-Tugai).
 
 <sub>Internal changes: dependency updates, move CI entirely to GitHub Actions.</sub>
+
+[#243](https://github.com/pitkley/dfw/pull/243)
 
 ## 1.1.0 - Bugfix, dependency updates (c9dc9ba)
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -141,8 +141,7 @@ where
         debug!(logger, "Got list of containers";
                o!("containers" => format!("{:#?}", containers)));
 
-        let container_map =
-            get_container_map(&containers)?.ok_or_else(|| format_err!("no containers found"))?;
+        let container_map = get_container_map(&containers)?;
         trace!(logger, "Got map of containers";
                o!("container_map" => format!("{:#?}", container_map)));
 
@@ -242,9 +241,7 @@ pub(crate) fn get_network_for_container(
     })
 }
 
-pub(crate) fn get_container_map(
-    containers: &[Container],
-) -> Result<Option<Map<String, Container>>> {
+pub(crate) fn get_container_map(containers: &[Container]) -> Result<Map<String, Container>> {
     let mut container_map: Map<String, Container> = Map::new();
     for container in containers {
         for name in &container.names {
@@ -255,11 +252,7 @@ pub(crate) fn get_container_map(
         }
     }
 
-    if container_map.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(container_map))
-    }
+    Ok(container_map)
 }
 
 pub(crate) fn get_network_map(


### PR DESCRIPTION
DFW can be used without any containers running, given that it performs
various actions that are not specific to a running container (managing
default policies, handling custom initialization rules).

Thanks to @Georgiy-Tugai for the initial pull-request!

Closes #243.

Co-authored-by: Georgiy Tugai <georgiy@crossings.link>