### PR TITLE
Change behaviour of `external_network_interfaces`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,22 @@
 ## Unreleased
 
 * Reintegrate the iptables-backend.
+
+    This reintroduces an iptables-based firewall-backend (v1.0 initially dropped iptables-support), specifically the iptables-restore backend that was made available in v0.4+.
+
+    The backend can be selected through the `--firewall-backend iptables` CLI parameter (`nftables` is the default).
+
 * Make exposing containers via IPv6 configurable.
+
+    You can now specify the `expose_via_ipv6`-key within a wider-world-to-container-rule to configure whether the service should be exposed via IPv6 or not (the default is `true`).
+
+    _(Please note that further requirements need to be fulfilled such that exposing services via IPv6 to works, [see here](https://github.com/pitkley/dfw/blob/master/README.md#ipv6support).)_
+
 * Ensure consistent behaviour regardless of whether `[global_defaults]` has been specified or not.
+
+    Previously DFW showed different behaviour depending on whether `global_defaults` was specified or not, regardless of the actual content within the section (which was allowed to be empty).
+    This release ensures that the same behaviour is maintained no matter if the section was defined or not.
+
 * Don't exit DFW if there are no containers running ([#243], thanks to @Georgiy-Tugai).
 * Remove overloaded use of `global_defaults.external_network_interfaces`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 * Make exposing containers via IPv6 configurable.
 * Ensure consistent behaviour regardless of whether `[global_defaults]` has been specified or not.
 * Don't exit DFW if there are no containers running ([#243], thanks to @Georgiy-Tugai).
+* Remove overloaded use of `global_defaults.external_network_interfaces`.
+
+    Previously if you defined the `global_defaults.external_network_interfaces` configuration key, the first interface provided would internally be used to restrict which interfaces traffic can ingress into your containers from, even if `wider_world_to_container.rules[].external_network_interfaces` was not defined.
+
+    This version changes the behaviour such that `global_defaults.external_network_interfaces` is no longer used to determine if traffic can ingress or not.
+    If you want to restrict traffic from reaching your containers to specific interfaces, use the `wider_world_to_container.rules[].external_network_interfaces` configuration key instead.
 
 <sub>Internal changes: dependency updates, move CI entirely to GitHub Actions.</sub>
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ If you are upgrading DFW but don't want to switch to nftables, you can provide t
 Please note that no matter if you transition to nftables or not, **v1.0 introduced breaking changes to the configuration**.
 Please consult the [migration documentation][migration-v0.x-to-v1.2] on how to update your configuration.
 
+[nftables]: https://netfilter.org/projects/nftables/
+
 -----
 
 1. [Overview](#overview)

--- a/resources/test/docker/05/iptables/expected-iptables-v4.txt
+++ b/resources/test/docker/05/iptables/expected-iptables-v4.txt
@@ -6,13 +6,13 @@
 -F DFWRS_FORWARD
 -A DFWRS_FORWARD -m state --state INVALID -j DROP
 -A DFWRS_FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT
--A DFWRS_FORWARD -d $dst_ip=ip -i eni -o $output=bridge -p tcp --dport 80 -j ACCEPT
--A DFWRS_FORWARD -d $dst_ip=ip -i eni -o $output=bridge -p tcp --dport 80 -j ACCEPT
--A DFWRS_FORWARD -d $dst_ip=ip -i eni -o $output=bridge -p udp --dport 53 -j ACCEPT
+-A DFWRS_FORWARD -d $dst_ip=ip -o $output=bridge -p tcp --dport 80 -j ACCEPT
+-A DFWRS_FORWARD -d $dst_ip=ip -o $output=bridge -p tcp --dport 80 -j ACCEPT
+-A DFWRS_FORWARD -d $dst_ip=ip -o $output=bridge -p udp --dport 53 -j ACCEPT
 -A DFWRS_FORWARD -d $dst_ip=ip -i other -o $output=bridge -p tcp --dport 443 -j ACCEPT
--A DFWRS_FORWARD -s 192.0.2.1/32 -d $dst_ip=ip -i eni -o $output=bridge -p tcp --dport 22 -j ACCEPT
--A DFWRS_FORWARD -s 192.0.2.2/32 -d $dst_ip=ip -i eni -o $output=bridge -p tcp --dport 25 -j ACCEPT
--A DFWRS_FORWARD -s 192.0.2.3/32 -d $dst_ip=ip -i eni -o $output=bridge -p tcp --dport 25 -j ACCEPT
+-A DFWRS_FORWARD -s 192.0.2.1/32 -d $dst_ip=ip -o $output=bridge -p tcp --dport 22 -j ACCEPT
+-A DFWRS_FORWARD -s 192.0.2.2/32 -d $dst_ip=ip -o $output=bridge -p tcp --dport 25 -j ACCEPT
+-A DFWRS_FORWARD -s 192.0.2.3/32 -d $dst_ip=ip -o $output=bridge -p tcp --dport 25 -j ACCEPT
 -A DFWRS_FORWARD -i docker0 -o eni -j ACCEPT
 -F DFWRS_INPUT
 -A DFWRS_INPUT -m state --state INVALID -j DROP
@@ -29,13 +29,13 @@ COMMIT
 -F DFWRS_POSTROUTING
 -A DFWRS_POSTROUTING -o eni -j MASQUERADE
 -F DFWRS_PREROUTING
--A DFWRS_PREROUTING -i eni -p tcp --dport 80 -j DNAT --to-destination ${dst_ip=ip}:80
--A DFWRS_PREROUTING -i eni -p tcp --dport 80 -j DNAT --to-destination ${dst_ip=ip}:80
--A DFWRS_PREROUTING -i eni -p udp --dport 53 -j DNAT --to-destination ${dst_ip=ip}:53
+-A DFWRS_PREROUTING -p tcp --dport 80 -j DNAT --to-destination ${dst_ip=ip}:80
+-A DFWRS_PREROUTING -p tcp --dport 80 -j DNAT --to-destination ${dst_ip=ip}:80
+-A DFWRS_PREROUTING -p udp --dport 53 -j DNAT --to-destination ${dst_ip=ip}:53
 -A DFWRS_PREROUTING -i other -p tcp --dport 443 -j DNAT --to-destination ${dst_ip=ip}:443
--A DFWRS_PREROUTING -s 192.0.2.1/32 -i eni -p tcp --dport 22 -j DNAT --to-destination ${dst_ip=ip}:22
--A DFWRS_PREROUTING -s 192.0.2.2/32 -i eni -p tcp --dport 25 -j DNAT --to-destination ${dst_ip=ip}:25
--A DFWRS_PREROUTING -s 192.0.2.3/32 -i eni -p tcp --dport 25 -j DNAT --to-destination ${dst_ip=ip}:25
+-A DFWRS_PREROUTING -s 192.0.2.1/32 -p tcp --dport 22 -j DNAT --to-destination ${dst_ip=ip}:22
+-A DFWRS_PREROUTING -s 192.0.2.2/32 -p tcp --dport 25 -j DNAT --to-destination ${dst_ip=ip}:25
+-A DFWRS_PREROUTING -s 192.0.2.3/32 -p tcp --dport 25 -j DNAT --to-destination ${dst_ip=ip}:25
 -A POSTROUTING -j DFWRS_POSTROUTING
 -A PREROUTING -j DFWRS_PREROUTING
 COMMIT

--- a/resources/test/docker/05/iptables/expected-iptables-v6.txt
+++ b/resources/test/docker/05/iptables/expected-iptables-v6.txt
@@ -7,13 +7,13 @@
 -F DFWRS_INPUT
 -A DFWRS_INPUT -m state --state INVALID -j DROP
 -A DFWRS_INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
--A DFWRS_INPUT -i eni -p tcp --dport 80 -j ACCEPT
--A DFWRS_INPUT -i eni -p tcp --dport 80 -j ACCEPT
--A DFWRS_INPUT -i eni -p udp --dport 53 -j ACCEPT
+-A DFWRS_INPUT -p tcp --dport 80 -j ACCEPT
+-A DFWRS_INPUT -p tcp --dport 80 -j ACCEPT
+-A DFWRS_INPUT -p udp --dport 53 -j ACCEPT
 -A DFWRS_INPUT -p tcp --dport 443 -j ACCEPT
--A DFWRS_INPUT -s 2001:db8::1/128 -i eni -p tcp --dport 22 -j ACCEPT
--A DFWRS_INPUT -s 2001:db8::2/128 -i eni -p tcp --dport 25 -j ACCEPT
--A DFWRS_INPUT -s 2001:db8::3/128 -i eni -p tcp --dport 25 -j ACCEPT
+-A DFWRS_INPUT -s 2001:db8::1/128 -p tcp --dport 22 -j ACCEPT
+-A DFWRS_INPUT -s 2001:db8::2/128 -p tcp --dport 25 -j ACCEPT
+-A DFWRS_INPUT -s 2001:db8::3/128 -p tcp --dport 25 -j ACCEPT
 COMMIT
 *nat
 :DFWRS_POSTROUTING - [0:0]

--- a/resources/test/docker/05/nftables/expected-nftables.txt
+++ b/resources/test/docker/05/nftables/expected-nftables.txt
@@ -18,24 +18,24 @@ add rule inet dfw input meta iifname docker0 meta mark set 0xdf accept
 add rule inet dfw forward meta iifname docker0 oifname eni meta mark set 0xdf accept
 add rule ip dfw postrouting meta oifname eni meta mark set 0xdf masquerade
 add rule ip6 dfw postrouting meta oifname eni meta mark set 0xdf masquerade
-add rule inet dfw forward tcp dport 80 ip daddr $dst_ip=ip meta iifname eni oifname $output=bridge meta mark set 0xdf accept
-add rule ip dfw prerouting tcp dport 80 meta iifname eni meta mark set 0xdf dnat ${dst_ip=ip}:80
-add rule ip6 dfw prerouting tcp dport 80 meta iifname eni meta mark set 0xdf
-add rule inet dfw forward tcp dport 80 ip daddr $dst_ip=ip meta iifname eni oifname $output=bridge meta mark set 0xdf accept
-add rule ip dfw prerouting tcp dport 80 meta iifname eni meta mark set 0xdf dnat ${dst_ip=ip}:80
-add rule ip6 dfw prerouting tcp dport 80 meta iifname eni meta mark set 0xdf
-add rule inet dfw forward udp dport 53 ip daddr $dst_ip=ip meta iifname eni oifname $output=bridge meta mark set 0xdf accept
-add rule ip dfw prerouting udp dport 53 meta iifname eni meta mark set 0xdf dnat ${dst_ip=ip}:53
-add rule ip6 dfw prerouting udp dport 53 meta iifname eni meta mark set 0xdf
+add rule inet dfw forward tcp dport 80 ip daddr $dst_ip=ip meta oifname $output=bridge meta mark set 0xdf accept
+add rule ip dfw prerouting tcp dport 80 meta mark set 0xdf dnat ${dst_ip=ip}:80
+add rule ip6 dfw prerouting tcp dport 80 meta mark set 0xdf
+add rule inet dfw forward tcp dport 80 ip daddr $dst_ip=ip meta oifname $output=bridge meta mark set 0xdf accept
+add rule ip dfw prerouting tcp dport 80 meta mark set 0xdf dnat ${dst_ip=ip}:80
+add rule ip6 dfw prerouting tcp dport 80 meta mark set 0xdf
+add rule inet dfw forward udp dport 53 ip daddr $dst_ip=ip meta oifname $output=bridge meta mark set 0xdf accept
+add rule ip dfw prerouting udp dport 53 meta mark set 0xdf dnat ${dst_ip=ip}:53
+add rule ip6 dfw prerouting udp dport 53 meta mark set 0xdf
 add rule inet dfw forward tcp dport 443 ip daddr $dst_ip=ip meta iifname other oifname $output=bridge meta mark set 0xdf accept
 add rule ip dfw prerouting tcp dport 443 meta iifname other meta mark set 0xdf dnat ${dst_ip=ip}:443
 add rule ip6 dfw prerouting tcp dport 443 meta iifname other meta mark set 0xdf
-add rule inet dfw forward tcp dport 22 ip saddr 192.0.2.1/32 ip daddr $dst_ip=ip meta iifname eni oifname $output=bridge meta mark set 0xdf accept
-add rule ip dfw prerouting tcp dport 22 ip saddr 192.0.2.1/32 meta iifname eni meta mark set 0xdf dnat ${dst_ip=ip}:22
-add rule ip6 dfw prerouting tcp dport 22 ip6 saddr 2001:db8::1/128 meta iifname eni meta mark set 0xdf
-add rule inet dfw forward tcp dport 25 ip saddr 192.0.2.2/32 ip daddr $dst_ip=ip meta iifname eni oifname $output=bridge meta mark set 0xdf accept
-add rule inet dfw forward tcp dport 25 ip saddr 192.0.2.3/32 ip daddr $dst_ip=ip meta iifname eni oifname $output=bridge meta mark set 0xdf accept
-add rule ip dfw prerouting tcp dport 25 ip saddr 192.0.2.2/32 meta iifname eni meta mark set 0xdf dnat ${dst_ip=ip}:25
-add rule ip dfw prerouting tcp dport 25 ip saddr 192.0.2.3/32 meta iifname eni meta mark set 0xdf dnat ${dst_ip=ip}:25
-add rule ip6 dfw prerouting tcp dport 25 ip6 saddr 2001:db8::2/128 meta iifname eni meta mark set 0xdf
-add rule ip6 dfw prerouting tcp dport 25 ip6 saddr 2001:db8::3/128 meta iifname eni meta mark set 0xdf
+add rule inet dfw forward tcp dport 22 ip saddr 192.0.2.1/32 ip daddr $dst_ip=ip meta oifname $output=bridge meta mark set 0xdf accept
+add rule ip dfw prerouting tcp dport 22 ip saddr 192.0.2.1/32 meta mark set 0xdf dnat ${dst_ip=ip}:22
+add rule ip6 dfw prerouting tcp dport 22 ip6 saddr 2001:db8::1/128 meta mark set 0xdf
+add rule inet dfw forward tcp dport 25 ip saddr 192.0.2.2/32 ip daddr $dst_ip=ip meta oifname $output=bridge meta mark set 0xdf accept
+add rule inet dfw forward tcp dport 25 ip saddr 192.0.2.3/32 ip daddr $dst_ip=ip meta oifname $output=bridge meta mark set 0xdf accept
+add rule ip dfw prerouting tcp dport 25 ip saddr 192.0.2.2/32 meta mark set 0xdf dnat ${dst_ip=ip}:25
+add rule ip dfw prerouting tcp dport 25 ip saddr 192.0.2.3/32 meta mark set 0xdf dnat ${dst_ip=ip}:25
+add rule ip6 dfw prerouting tcp dport 25 ip6 saddr 2001:db8::2/128 meta mark set 0xdf
+add rule ip6 dfw prerouting tcp dport 25 ip6 saddr 2001:db8::3/128 meta mark set 0xdf

--- a/resources/test/docker/07/iptables/expected-iptables-v4.txt
+++ b/resources/test/docker/07/iptables/expected-iptables-v4.txt
@@ -6,12 +6,12 @@
 -F DFWRS_FORWARD
 -A DFWRS_FORWARD -m state --state INVALID -j DROP
 -A DFWRS_FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT
--A DFWRS_FORWARD -d $dst_ip=ip -i eni -o $output=bridge -p tcp --dport 1010 -j ACCEPT
--A DFWRS_FORWARD -d $dst_ip=ip -i eni -o $output=bridge -p tcp --dport 2010 -j ACCEPT
--A DFWRS_FORWARD -s 192.0.2.2/32 -d $dst_ip=ip -i eni -o $output=bridge -p tcp --dport 1020 -j ACCEPT
--A DFWRS_FORWARD -s 192.0.2.3/32 -d $dst_ip=ip -i eni -o $output=bridge -p tcp --dport 1020 -j ACCEPT
--A DFWRS_FORWARD -s 192.0.2.2/32 -d $dst_ip=ip -i eni -o $output=bridge -p tcp --dport 2020 -j ACCEPT
--A DFWRS_FORWARD -s 192.0.2.3/32 -d $dst_ip=ip -i eni -o $output=bridge -p tcp --dport 2020 -j ACCEPT
+-A DFWRS_FORWARD -d $dst_ip=ip -o $output=bridge -p tcp --dport 1010 -j ACCEPT
+-A DFWRS_FORWARD -d $dst_ip=ip -o $output=bridge -p tcp --dport 2010 -j ACCEPT
+-A DFWRS_FORWARD -s 192.0.2.2/32 -d $dst_ip=ip -o $output=bridge -p tcp --dport 1020 -j ACCEPT
+-A DFWRS_FORWARD -s 192.0.2.3/32 -d $dst_ip=ip -o $output=bridge -p tcp --dport 1020 -j ACCEPT
+-A DFWRS_FORWARD -s 192.0.2.2/32 -d $dst_ip=ip -o $output=bridge -p tcp --dport 2020 -j ACCEPT
+-A DFWRS_FORWARD -s 192.0.2.3/32 -d $dst_ip=ip -o $output=bridge -p tcp --dport 2020 -j ACCEPT
 -A DFWRS_FORWARD -i docker0 -o eni -j ACCEPT
 -F DFWRS_INPUT
 -A DFWRS_INPUT -m state --state INVALID -j DROP
@@ -28,12 +28,12 @@ COMMIT
 -F DFWRS_POSTROUTING
 -A DFWRS_POSTROUTING -o eni -j MASQUERADE
 -F DFWRS_PREROUTING
--A DFWRS_PREROUTING -i eni -p tcp --dport 1010 -j DNAT --to-destination ${dst_ip=ip}:1010
--A DFWRS_PREROUTING -i eni -p tcp --dport 2010 -j DNAT --to-destination ${dst_ip=ip}:2010
--A DFWRS_PREROUTING -s 192.0.2.2/32 -i eni -p tcp --dport 1020 -j DNAT --to-destination ${dst_ip=ip}:1020
--A DFWRS_PREROUTING -s 192.0.2.3/32 -i eni -p tcp --dport 1020 -j DNAT --to-destination ${dst_ip=ip}:1020
--A DFWRS_PREROUTING -s 192.0.2.2/32 -i eni -p tcp --dport 2020 -j DNAT --to-destination ${dst_ip=ip}:2020
--A DFWRS_PREROUTING -s 192.0.2.3/32 -i eni -p tcp --dport 2020 -j DNAT --to-destination ${dst_ip=ip}:2020
+-A DFWRS_PREROUTING -p tcp --dport 1010 -j DNAT --to-destination ${dst_ip=ip}:1010
+-A DFWRS_PREROUTING -p tcp --dport 2010 -j DNAT --to-destination ${dst_ip=ip}:2010
+-A DFWRS_PREROUTING -s 192.0.2.2/32 -p tcp --dport 1020 -j DNAT --to-destination ${dst_ip=ip}:1020
+-A DFWRS_PREROUTING -s 192.0.2.3/32 -p tcp --dport 1020 -j DNAT --to-destination ${dst_ip=ip}:1020
+-A DFWRS_PREROUTING -s 192.0.2.2/32 -p tcp --dport 2020 -j DNAT --to-destination ${dst_ip=ip}:2020
+-A DFWRS_PREROUTING -s 192.0.2.3/32 -p tcp --dport 2020 -j DNAT --to-destination ${dst_ip=ip}:2020
 -A POSTROUTING -j DFWRS_POSTROUTING
 -A PREROUTING -j DFWRS_PREROUTING
 COMMIT

--- a/resources/test/docker/07/iptables/expected-iptables-v6.txt
+++ b/resources/test/docker/07/iptables/expected-iptables-v6.txt
@@ -7,9 +7,9 @@
 -F DFWRS_INPUT
 -A DFWRS_INPUT -m state --state INVALID -j DROP
 -A DFWRS_INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
--A DFWRS_INPUT -i eni -p tcp --dport 1010 -j ACCEPT
--A DFWRS_INPUT -s 2001:db8::2/128 -i eni -p tcp --dport 1020 -j ACCEPT
--A DFWRS_INPUT -s 2001:db8::3/128 -i eni -p tcp --dport 1020 -j ACCEPT
+-A DFWRS_INPUT -p tcp --dport 1010 -j ACCEPT
+-A DFWRS_INPUT -s 2001:db8::2/128 -p tcp --dport 1020 -j ACCEPT
+-A DFWRS_INPUT -s 2001:db8::3/128 -p tcp --dport 1020 -j ACCEPT
 COMMIT
 *nat
 :DFWRS_POSTROUTING - [0:0]

--- a/resources/test/docker/07/nftables/expected-nftables.txt
+++ b/resources/test/docker/07/nftables/expected-nftables.txt
@@ -18,18 +18,18 @@ add rule inet dfw input meta iifname docker0 meta mark set 0xdf accept
 add rule inet dfw forward meta iifname docker0 oifname eni meta mark set 0xdf accept
 add rule ip dfw postrouting meta oifname eni meta mark set 0xdf masquerade
 add rule ip6 dfw postrouting meta oifname eni meta mark set 0xdf masquerade
-add rule inet dfw forward tcp dport 1010 ip daddr $dst_ip=ip meta iifname eni oifname $output=bridge meta mark set 0xdf accept
-add rule ip dfw prerouting tcp dport 1010 meta iifname eni meta mark set 0xdf dnat ${dst_ip=ip}:1010
-add rule ip6 dfw prerouting tcp dport 1010 meta iifname eni meta mark set 0xdf
-add rule inet dfw forward tcp dport 2010 ip daddr $dst_ip=ip meta iifname eni oifname $output=bridge meta mark set 0xdf accept
-add rule ip dfw prerouting tcp dport 2010 meta iifname eni meta mark set 0xdf dnat ${dst_ip=ip}:2010
-add rule inet dfw forward tcp dport 1020 ip saddr 192.0.2.2/32 ip daddr $dst_ip=ip meta iifname eni oifname $output=bridge meta mark set 0xdf accept
-add rule inet dfw forward tcp dport 1020 ip saddr 192.0.2.3/32 ip daddr $dst_ip=ip meta iifname eni oifname $output=bridge meta mark set 0xdf accept
-add rule ip dfw prerouting tcp dport 1020 ip saddr 192.0.2.2/32 meta iifname eni meta mark set 0xdf dnat ${dst_ip=ip}:1020
-add rule ip dfw prerouting tcp dport 1020 ip saddr 192.0.2.3/32 meta iifname eni meta mark set 0xdf dnat ${dst_ip=ip}:1020
-add rule ip6 dfw prerouting tcp dport 1020 ip6 saddr 2001:db8::2/128 meta iifname eni meta mark set 0xdf
-add rule ip6 dfw prerouting tcp dport 1020 ip6 saddr 2001:db8::3/128 meta iifname eni meta mark set 0xdf
-add rule inet dfw forward tcp dport 2020 ip saddr 192.0.2.2/32 ip daddr $dst_ip=ip meta iifname eni oifname $output=bridge meta mark set 0xdf accept
-add rule inet dfw forward tcp dport 2020 ip saddr 192.0.2.3/32 ip daddr $dst_ip=ip meta iifname eni oifname $output=bridge meta mark set 0xdf accept
-add rule ip dfw prerouting tcp dport 2020 ip saddr 192.0.2.2/32 meta iifname eni meta mark set 0xdf dnat ${dst_ip=ip}:2020
-add rule ip dfw prerouting tcp dport 2020 ip saddr 192.0.2.3/32 meta iifname eni meta mark set 0xdf dnat ${dst_ip=ip}:2020
+add rule inet dfw forward tcp dport 1010 ip daddr $dst_ip=ip meta oifname $output=bridge meta mark set 0xdf accept
+add rule ip dfw prerouting tcp dport 1010 meta mark set 0xdf dnat ${dst_ip=ip}:1010
+add rule ip6 dfw prerouting tcp dport 1010 meta mark set 0xdf
+add rule inet dfw forward tcp dport 2010 ip daddr $dst_ip=ip meta oifname $output=bridge meta mark set 0xdf accept
+add rule ip dfw prerouting tcp dport 2010 meta mark set 0xdf dnat ${dst_ip=ip}:2010
+add rule inet dfw forward tcp dport 1020 ip saddr 192.0.2.2/32 ip daddr $dst_ip=ip meta oifname $output=bridge meta mark set 0xdf accept
+add rule inet dfw forward tcp dport 1020 ip saddr 192.0.2.3/32 ip daddr $dst_ip=ip meta oifname $output=bridge meta mark set 0xdf accept
+add rule ip dfw prerouting tcp dport 1020 ip saddr 192.0.2.2/32 meta mark set 0xdf dnat ${dst_ip=ip}:1020
+add rule ip dfw prerouting tcp dport 1020 ip saddr 192.0.2.3/32 meta mark set 0xdf dnat ${dst_ip=ip}:1020
+add rule ip6 dfw prerouting tcp dport 1020 ip6 saddr 2001:db8::2/128 meta mark set 0xdf
+add rule ip6 dfw prerouting tcp dport 1020 ip6 saddr 2001:db8::3/128 meta mark set 0xdf
+add rule inet dfw forward tcp dport 2020 ip saddr 192.0.2.2/32 ip daddr $dst_ip=ip meta oifname $output=bridge meta mark set 0xdf accept
+add rule inet dfw forward tcp dport 2020 ip saddr 192.0.2.3/32 ip daddr $dst_ip=ip meta oifname $output=bridge meta mark set 0xdf accept
+add rule ip dfw prerouting tcp dport 2020 ip saddr 192.0.2.2/32 meta mark set 0xdf dnat ${dst_ip=ip}:2020
+add rule ip dfw prerouting tcp dport 2020 ip saddr 192.0.2.3/32 meta mark set 0xdf dnat ${dst_ip=ip}:2020

--- a/src/nftables/process.rs
+++ b/src/nftables/process.rs
@@ -542,12 +542,6 @@ impl Process<Nftables> for ContainerToWiderWorldRule {
             trace!(ctx.logger, "Rule has specific external network interface";
                        o!("external_network_interface" => external_network_interface));
             nft_rule.out_interface(external_network_interface);
-        } else if let Some(ref primary_external_network_interface) =
-            ctx.primary_external_network_interface
-        {
-            trace!(ctx.logger, "Rule uses primary external network interface";
-                       o!("external_network_interface" => primary_external_network_interface));
-            nft_rule.out_interface(primary_external_network_interface);
         }
 
         let rule = nft_rule.build()?;
@@ -870,18 +864,6 @@ impl Process<Nftables> for WiderWorldToContainerRule {
                 nft_forward_rule.in_interface(external_network_interface);
                 nft_dnat_rule.in_interface(external_network_interface);
                 nft_mark_rule.in_interface(external_network_interface);
-            } else if let Some(ref primary_external_network_interface) =
-                ctx.primary_external_network_interface
-            {
-                trace!(ctx.logger, "Rule uses primary external network interface";
-                       o!("external_network_interface" => primary_external_network_interface));
-
-                nft_forward_rule.in_interface(primary_external_network_interface);
-                nft_dnat_rule.in_interface(primary_external_network_interface);
-                nft_mark_rule.in_interface(primary_external_network_interface);
-            } else {
-                // The DNAT rule requires the external interface
-                return Ok(None);
             }
 
             // If source CIDRs have been specified, create the FORWARD-rules as required to

--- a/src/process.rs
+++ b/src/process.rs
@@ -111,7 +111,6 @@ where
     pub(crate) container_map: Map<String, Container>,
     pub(crate) network_map: Map<String, NetworkDetails>,
     pub(crate) external_network_interfaces: Option<Vec<String>>,
-    pub(crate) primary_external_network_interface: Option<String>,
     pub(crate) logger: Logger,
     pub(crate) dry_run: bool,
 }
@@ -159,10 +158,6 @@ where
             .external_network_interfaces
             .as_ref()
             .cloned();
-        let primary_external_network_interface = external_network_interfaces
-            .as_ref()
-            .and_then(|v| v.get(0))
-            .map(|s| s.to_owned());
 
         Ok(ProcessContext {
             docker,
@@ -170,7 +165,6 @@ where
             container_map,
             network_map,
             external_network_interfaces,
-            primary_external_network_interface,
             logger,
             dry_run,
         })

--- a/src/types.rs
+++ b/src/types.rs
@@ -121,8 +121,10 @@ where
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq, Hash, Default)]
 #[serde(deny_unknown_fields)]
 pub struct GlobalDefaults {
-    /// This defines the external network interfaces of the host to consider during building the
-    /// rules. The value can be non-existent, a string, or a sequence of strings.
+    /// This defines the external network interfaces the containers managed through DFW should be
+    /// able to communicate through (i.e. outbound communication with the wider world).
+    ///
+    /// The value can be unset, a string, or a sequence of strings.
     ///
     /// # Example
     ///


### PR DESCRIPTION
Previously if you defined the `global_defaults.external_network_interfaces` configuration key, the first interface provided would internally be used to restrict which interfaces traffic can ingress into your containers from, even if `wider_world_to_container.rules[].external_network_interfaces` was not defined.

This version changes the behaviour such that `global_defaults.external_network_interfaces` is no longer used to determine if traffic can ingress or not. If you want to restrict traffic
from reaching your containers to specific interfaces, use the `wider_world_to_container.rules[].external_network_interfaces` configuration key instead.

Closes #277.
