### PR TITLE
Allow dead code on struct that derives builder

### DIFF
--- a/src/nftables/rule.rs
+++ b/src/nftables/rule.rs
@@ -13,6 +13,7 @@ use failure::bail;
 
 #[derive(Debug, Clone, Builder)]
 #[builder(derive(Debug), pattern = "mutable", build_fn(skip))]
+#[allow(dead_code)]
 pub(crate) struct Rule {
     #[builder(setter(into))]
     pub in_interface: String,


### PR DESCRIPTION
The struct is just the means to an end: internally we only use the
automatically created builder, which means clippy is not wrong about the
fields not being used directly, but they are used indirectly to derive
the `RuleBuilder`.