### PR TITLE
Build Docker images for multiple platforms/architectures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Setup connection to arm64-capable runner
+      run: |
+        echo "::group::ssh-agent: launch and export"
+        eval "$(ssh-agent)"
+        echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV
+        echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> $GITHUB_ENV
+        echo "::endgroup::"
+
+        echo "::group::ssh-agent: load private key"
+        ssh-add - <<< "${{ secrets.ARMRUNNER1_SSH_PRIVATE_KEY }}"
+        echo "::endgroup::"
+
+        echo "::group::ssh: pin runner public key"
+        mkdir ~/.ssh && chmod 0700 ~/.ssh || :
+        echo "[${{ secrets.ARMRUNNER1_HOSTNAME }}]:${{ secrets.ARMRUNNER1_SSH_PORT }} ${{ secrets.ARMRUNNER1_SSH_HOSTKEY }}" > ~/.ssh/known_hosts
+        echo "::endgroup::"
+
+    - name: Register arm64-capable runner with Buildx
+      env:
+        DOCKER_HOST: ssh://github-actions@${{ secrets.ARMRUNNER1_HOSTNAME }}:${{ secrets.ARMRUNNER1_SSH_PORT }}
+      run: docker buildx create --append --name ${{ steps.buildx.outputs.name }} --bootstrap
+
     - name: Checkout
       uses: actions/checkout@v2
 
@@ -58,6 +84,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -101,6 +101,7 @@ jobs:
           ```
 
           This will download a lightweight image, coming in at under 10 MB, and subsequently run it using your configuration.
+          The image supports multiple architectures: `amd64`, `arm64`, `armv7` (specifically `armhf`).
 
     - name: Upload static DFW binary
       uses: actions/upload-release-asset@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 
   (Required after updating dependencies.)
 
+* Build Docker images for multiple architectures: `amd64`, `arm64`, `arm/v7`.
+
+    This allows users to pull the image from Docker Hub or GHCR for any of the mentioned architectures (from the same tag).
+
 <sub>Internal changes: dependency updates, CI updates.</sub>
 
 ## 1.2.1 (2020-12-13)

--- a/README.md
+++ b/README.md
@@ -93,22 +93,16 @@ You can of course bind the port to `127.0.0.1`, but you have to be explicit abou
 
 ## <a name="gettingstarted"></a> Getting started
 
-If you are already a user of DFW and are looking to upgrade to a newer version, consult the matching migration documentation:
-
-* [Migrating from DFW 1.x to 1.2][migration-v1.x-to-v1.2]
-* [Migrating from DFW 0.x to 1.2][migration-v0.x-to-v1.2]
-* ~~[Migrating from DFW 0.x to 1.0][migration-v0.x-to-v1.0]~~
-
 If you are starting fresh, the first step is to decide on a firewall backend:
 
-* nftables
+* [nftables][docs-nftables]
 
     nftables can be seen as a newer generation of iptables, and it will replace iptables in most Linux distributions at some point.
     (It already is the default in e.g. Debian 10 Buster.)
 
     If you are starting fresh on a host where you have not used either backend yet, nftables is the suggested backend.
 
-* iptables
+* [iptables][docs-iptables]
 
     While iptables is the older netfilter implementation, it is still a valid firewall-backend and still finds extensive use across many distributions.
 
@@ -119,7 +113,11 @@ Once you have decided which backend you want to use, please consult the backend-
 * [nftables][docs-nftables]
 * [iptables][docs-iptables]
 
-[migration-v0.x-to-v1.0]: https://github.com/pitkley/dfw/blob/main/docs/migration/v0.x-to-v1.0.md
+If you are already a user of DFW and are looking to upgrade to a newer version, consult the matching migration documentation:
+
+* [Migrating from DFW 1.x to 1.2][migration-v1.x-to-v1.2]
+* [Migrating from DFW 0.x to 1.2][migration-v0.x-to-v1.2]
+
 [migration-v0.x-to-v1.2]: https://github.com/pitkley/dfw/blob/main/docs/migration/v0.x-to-v1.2.md
 [migration-v1.x-to-v1.2]: https://github.com/pitkley/dfw/blob/main/docs/migration/v1.x-to-v1.2.md
 [docs-nftables]: https://github.com/pitkley/dfw/blob/main/docs/GETTING-STARTED-nftables.md

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Please consult the [migration documentation][migration-v0.x-to-v1.2] on how to u
 3. [Configuration](#configuration)
 4. [IPv6 support](#ipv6support)
     1. [Example: webserver reachable via IPv6](#ipv6support-example)
-5. [Supported Docker versions](#supporteddockerversions)
-6. [Version bump policy](#versionbumppolicy)
-7. [License](#license)
+5. [Supported architectures](#supportedarchitectures)
+6. [Supported Docker versions](#supporteddockerversions)
+7. [Version bump policy](#versionbumppolicy)
+8. [License](#license)
     1. [Contribution](#license-contribution)
 
 -----
@@ -214,6 +215,21 @@ expose_port = [
 ```
 
 The result of this is that your container will be reachable from the host-ports 80 and 443, from both IPv4 and IPv6.
+
+## <a name="supportedarchitectures"></a> Supported architectures
+
+The Docker image for DFW is pre-built for the following architectures:
+
+* `amd64` (a.k.a. `x86_64`)
+* `arm64` (a.k.a. `aarch64`)
+* `arm/v7` (specifically `armhf`)
+
+You don't have to do anything special to use the correct architecture: just `docker pull pitkley/dfw:1.2.1`.
+Docker will take care of pulling the image that matches the architecture of your host.
+
+In general, DFW should be able to run on any architecture that [Rust supports][rust-platform-support] and for which the `nftables` or `iptables` binaries exist.
+
+[rust-platform-support]: https://doc.rust-lang.org/stable/rustc/platform-support.html
 
 ## <a name="supporteddockerversions"></a> Supported Docker versions
 

--- a/docs/GETTING-STARTED-iptables.md
+++ b/docs/GETTING-STARTED-iptables.md
@@ -103,13 +103,21 @@ $ docker run -d \
 ```
 
 This will download a lightweight image, coming in at under 10 MB, and subsequently run it using your configuration.
+The image supports multiple architectures: `amd64`, `arm64`, `armv7` (specifically `armhf`).
+
+Please note that you can also pull the image from the GitHub container registry, GHCR, if you want to avoid potential pull-limitations Docker Hub has put in place:
+
+```console
+$ docker pull ghcr.io/pitkley/dfw:1.2.1
+$ docker run ... ghcr.io/pitkley/dfw:1.2.1 ...
+```
 
 ### Using a pre-built binary directly on your host.
 
 You can retrieve the latest pre-built binary from the GitHub releases page:
 
-* [Release page](https://github.com/pitkley/dfw-ghtest/releases/latest)
-* [Direct download](https://github.com/pitkley/dfw-ghtest/releases/latest/download/dfw-x86_64-unknown-linux-musl) (static Linux x86_64 binary, no further dependencies required)
+* [Release page](https://github.com/pitkley/dfw/releases/latest)
+* [Direct download](https://github.com/pitkley/dfw/releases/latest/download/dfw-x86_64-unknown-linux-musl) (static Linux x86_64 binary, no further dependencies required)
 
 ### Install DFW through crates.io.
 

--- a/docs/GETTING-STARTED-nftables.md
+++ b/docs/GETTING-STARTED-nftables.md
@@ -153,16 +153,43 @@ $ docker run -d \
 ```
 
 This will download a lightweight image, coming in at under 10 MB, and subsequently run it using your configuration.
+The image supports multiple architectures: `amd64`, `arm64`, `armv7` (specifically `armhf`).
 
-### As a binary directly on your host
+Please note that you can also pull the image from the GitHub container registry, GHCR, if you want to avoid potential pull-limitations Docker Hub has put in place:
 
-We currently do not provide any pre-built binaries (aside from the Docker image), so you will have to build the binary yourself.
-For this you need to first [install Rust][rustlang-install] and then install DFW:
+```console
+$ docker pull ghcr.io/pitkley/dfw:1.2.1
+$ docker run ... ghcr.io/pitkley/dfw:1.2.1 ...
+```
+
+### Using a pre-built binary directly on your host.
+
+You can retrieve the latest pre-built binary from the GitHub releases page:
+
+* [Release page](https://github.com/pitkley/dfw/releases/latest)
+* [Direct download](https://github.com/pitkley/dfw/releases/latest/download/dfw-x86_64-unknown-linux-musl) (static Linux x86_64 binary, no further dependencies required)
+
+### Install DFW through crates.io.
+
+For this you need to first [install Rust][rustlang-install] and then install DFW using cargo:
 
 ```console
 $ cargo install dfw
 $ dfw --help
 dfw 1.2.1
+Docker Firewall Framework, in Rust
+...
+```
+### Build from source.
+
+For this you need to first [install Rust][rustlang-install].
+You can then check out the repository and build the binary:
+
+```console
+$ git checkout https://github.com/pitkley/dfw
+$ cd dfw/
+$ cargo build --release
+$ target/release/dfw
 Docker Firewall Framework, in Rust
 ...
 ```

--- a/release.toml
+++ b/release.toml
@@ -3,6 +3,11 @@ tag-name = "{{version}}"
 
 # Replace `docker pull pitkley/dfw:X.Y.Z`
 [[pre-release-replacements]]
+file = "README.md"
+search = "pitkley/dfw:([0-9]+\\.?)+"
+replace = "pitkley/dfw:{{version}}"
+prerelease = false
+[[pre-release-replacements]]
 file = "docs/GETTING-STARTED-nftables.md"
 search = "pitkley/dfw:([0-9]+\\.?)+"
 replace = "pitkley/dfw:{{version}}"


### PR DESCRIPTION
- [x] Reword commit
- [x] Check if we want to build/include prebuilt binaries on releasing for `arm64` and Arm v7 (`armhf` and/or `armel`) (as part of this PR or in just in general).
- [x] Add changelog entry, modify README to reflect supported architectures, modify releasing text if applicable 