### PR TITLE
Add support for custom bridge interface names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "dfw"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "bollard",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfw"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 authors = ["Pit Kleyersburg <pitkley@googlemail.com>"]
 license = "MIT/Apache-2.0"

--- a/src/iptables/process.rs
+++ b/src/iptables/process.rs
@@ -254,8 +254,7 @@ impl Process<Iptables> for ContainerToContainer {
 
         if let Some(same_network_verdict) = self.same_network_verdict {
             for network in ctx.network_map.values() {
-                let network_id = network.id.as_ref().expect("Docker network ID missing");
-                let bridge_name = get_bridge_name(network_id)?;
+                let bridge_name = get_bridge_name(network)?;
                 trace!(ctx.logger, "Got bridge name";
                        o!("network_name" => &network.name,
                           "bridge_name" => &bridge_name));
@@ -304,7 +303,7 @@ impl Process<Iptables> for ContainerToContainerRule {
                   "network" => format!("{:?}", network)));
 
         let network_id = network.id.as_ref().expect("Docker network ID missing");
-        let bridge_name = get_bridge_name(network_id)?;
+        let bridge_name = get_bridge_name(network)?;
         trace!(ctx.logger, "Got bridge name";
                o!("network_name" => &network.name,
                   "bridge_name" => &bridge_name));
@@ -327,7 +326,7 @@ impl Process<Iptables> for ContainerToContainerRule {
                    o!("network_name" => &network.name,
                       "src_network" => format!("{:?}", src_network)));
 
-            let bridge_name = get_bridge_name(network_id)?;
+            let bridge_name = get_bridge_name(network)?;
             trace!(ctx.logger, "Got bridge name";
                    o!("network_name" => &network.name,
                       "bridge_name" => &bridge_name));
@@ -359,7 +358,7 @@ impl Process<Iptables> for ContainerToContainerRule {
                    o!("network_name" => &network.name,
                       "dst_network" => format!("{:?}", dst_network)));
 
-            let bridge_name = get_bridge_name(network_id)?;
+            let bridge_name = get_bridge_name(network)?;
             trace!(ctx.logger, "Got bridge name";
                    o!("network_name" => &network.name,
                       "bridge_name" => &bridge_name));
@@ -415,8 +414,7 @@ impl Process<Iptables> for ContainerToWiderWorld {
                           "external_network_interface" => external_network_interface,
                           "default_policy" => &self.default_policy));
                 for network in ctx.network_map.values() {
-                    let network_id = network.id.as_ref().expect("Docker network ID missing");
-                    let bridge_name = get_bridge_name(network_id)?;
+                    let bridge_name = get_bridge_name(network)?;
                     trace!(ctx.logger, "Got bridge name";
                            o!("network_name" => &network.name,
                               "bridge_name" => &bridge_name));
@@ -464,7 +462,7 @@ impl Process<Iptables> for ContainerToWiderWorldRule {
                                o!("network_name" => &network.name,
                                   "src_network" => format!("{:?}", src_network)));
 
-                        let bridge_name = get_bridge_name(network_id)?;
+                        let bridge_name = get_bridge_name(network)?;
                         trace!(ctx.logger, "Got bridge name";
                                o!("network_name" => &network.name,
                                   "bridge_name" => &bridge_name));
@@ -479,7 +477,7 @@ impl Process<Iptables> for ContainerToWiderWorldRule {
                         );
                     }
                 } else {
-                    let bridge_name = get_bridge_name(network_id)?;
+                    let bridge_name = get_bridge_name(network)?;
                     trace!(ctx.logger, "Got bridge name";
                            o!("network_name" => &network.name,
                               "bridge_name" => &bridge_name));
@@ -540,8 +538,7 @@ impl Process<Iptables> for ContainerToHost {
 
         // Default policy
         for network in ctx.network_map.values() {
-            let network_id = network.id.as_ref().expect("Docker network ID missing");
-            let bridge_name = get_bridge_name(network_id)?;
+            let bridge_name = get_bridge_name(network)?;
             trace!(ctx.logger, "Got bridge name";
                    o!("network_name" => &network.name,
                       "bridge_name" => &bridge_name));
@@ -578,7 +575,7 @@ impl Process<Iptables> for ContainerToHostRule {
                   "network" => format!("{:?}", network)));
 
         let network_id = network.id.as_ref().expect("Docker network ID missing");
-        let bridge_name = get_bridge_name(network_id)?;
+        let bridge_name = get_bridge_name(network)?;
         trace!(ctx.logger, "Got bridge name";
                o!("network_name" => &network.name,
                   "bridge_name" => &bridge_name));
@@ -671,7 +668,7 @@ impl Process<Iptables> for WiderWorldToContainerRule {
                       "network" => format!("{:?}", network)));
 
             let network_id = network.id.as_ref().expect("Docker network ID missing");
-            let bridge_name = get_bridge_name(network_id)?;
+            let bridge_name = get_bridge_name(network)?;
             trace!(ctx.logger, "Got bridge name";
                    o!("network_name" => &network.name,
                       "bridge_name" => &bridge_name));
@@ -883,7 +880,7 @@ impl Process<Iptables> for ContainerDNATRule {
                               "network" => format!("{:?}", network)));
 
                     let network_id = network.id.as_ref().expect("Docker network ID missing");
-                    let bridge_name = get_bridge_name(network_id)?;
+                    let bridge_name = get_bridge_name(network)?;
                     trace!(ctx.logger, "Got bridge name";
                            o!("network_name" => &network.name,
                               "bridge_name" => &bridge_name));
@@ -901,7 +898,7 @@ impl Process<Iptables> for ContainerDNATRule {
                                    o!("network_name" => &network.name,
                                       "src_network" => format!("{:?}", src_network)));
 
-                            let bridge_name = get_bridge_name(network_id)?;
+                            let bridge_name = get_bridge_name(network)?;
                             trace!(ctx.logger, "Got bridge name";
                                    o!("network_name" => &network.name,
                                       "bridge_name" => &bridge_name));
@@ -937,7 +934,7 @@ impl Process<Iptables> for ContainerDNATRule {
                    o!("network_name" => &network.name,
                       "dst_network" => format!("{:?}", dst_network)));
 
-            let bridge_name = get_bridge_name(network_id)?;
+            let bridge_name = get_bridge_name(network)?;
             trace!(ctx.logger, "Got bridge name";
                    o!("network_name" => &network.name,
                       "bridge_name" => &bridge_name));

--- a/src/nftables/process.rs
+++ b/src/nftables/process.rs
@@ -332,8 +332,7 @@ impl Process<Nftables> for ContainerToContainer {
 
         if let Some(same_network_verdict) = self.same_network_verdict {
             for network in ctx.network_map.values() {
-                let network_id = network.id.as_ref().expect("Docker network ID missing");
-                let bridge_name = get_bridge_name(network_id)?;
+                let bridge_name = get_bridge_name(network)?;
                 trace!(ctx.logger, "Got bridge name";
                        o!("network_name" => &network.name,
                           "bridge_name" => &bridge_name));
@@ -370,7 +369,7 @@ impl Process<Nftables> for ContainerToContainerRule {
                     o!("network_name" => &self.network,
                         "network" => format!("{:?}", network)));
         let network_id = network.id.as_ref().expect("Docker network ID missing");
-        let bridge_name = get_bridge_name(network_id)?;
+        let bridge_name = get_bridge_name(network)?;
         trace!(ctx.logger, "Got bridge name";
                     o!("network_name" => &network.name,
                         "bridge_name" => &bridge_name));
@@ -394,7 +393,7 @@ impl Process<Nftables> for ContainerToContainerRule {
                         o!("network_name" => &network.name,
                             "src_network" => format!("{:?}", src_network)));
 
-            let bridge_name = get_bridge_name(network_id)?;
+            let bridge_name = get_bridge_name(network)?;
             trace!(ctx.logger, "Got bridge name";
                         o!("network_name" => &network.name,
                             "bridge_name" => &bridge_name));
@@ -426,8 +425,7 @@ impl Process<Nftables> for ContainerToContainerRule {
                         o!("network_name" => &network.name,
                             "dst_network" => format!("{:?}", dst_network)));
 
-            let network_id = network.id.as_ref().expect("Docker network ID missing");
-            let bridge_name = get_bridge_name(network_id)?;
+            let bridge_name = get_bridge_name(network)?;
             trace!(ctx.logger, "Got bridge name";
                         o!("network_name" => &network.name,
                             "bridge_name" => &bridge_name));
@@ -474,8 +472,7 @@ impl Process<Nftables> for ContainerToWiderWorld {
                           "external_network_interface" => external_network_interface,
                           "default_policy" => &self.default_policy));
                 for network in ctx.network_map.values() {
-                    let network_id = network.id.as_ref().expect("Docker network ID missing");
-                    let bridge_name = get_bridge_name(network_id)?;
+                    let bridge_name = get_bridge_name(network)?;
                     trace!(ctx.logger, "Got bridge name";
                            o!("network_name" => &network.name,
                               "bridge_name" => &bridge_name));
@@ -512,7 +509,7 @@ impl Process<Nftables> for ContainerToWiderWorldRule {
         if let Some(ref network) = self.network {
             if let Some(network) = ctx.network_map.get(network) {
                 let network_id = network.id.as_ref().expect("Docker network ID missing");
-                let bridge_name = get_bridge_name(network_id)?;
+                let bridge_name = get_bridge_name(network)?;
                 trace!(ctx.logger, "Got bridge name";
                            o!("network_name" => &network.name,
                               "bridge_name" => &bridge_name));
@@ -530,7 +527,7 @@ impl Process<Nftables> for ContainerToWiderWorldRule {
                                    o!("network_name" => &network.name,
                                       "src_network" => format!("{:?}", src_network)));
 
-                        let bridge_name = get_bridge_name(network_id)?;
+                        let bridge_name = get_bridge_name(network)?;
                         trace!(ctx.logger, "Got bridge name";
                                    o!("network_name" => &network.name,
                                       "bridge_name" => &bridge_name));
@@ -545,7 +542,7 @@ impl Process<Nftables> for ContainerToWiderWorldRule {
                         );
                     }
                 } else {
-                    let bridge_name = get_bridge_name(network_id)?;
+                    let bridge_name = get_bridge_name(network)?;
                     trace!(ctx.logger, "Got bridge name";
                                o!("network_name" => &network.name,
                                   "bridge_name" => &bridge_name));
@@ -603,8 +600,7 @@ impl Process<Nftables> for ContainerToHost {
 
         // Default policy
         for network in ctx.network_map.values() {
-            let network_id = network.id.as_ref().expect("Docker network ID missing");
-            let bridge_name = get_bridge_name(network_id)?;
+            let bridge_name = get_bridge_name(network)?;
             trace!(ctx.logger, "Got bridge name";
                    o!("network_name" => &network.name,
                       "bridge_name" => &bridge_name));
@@ -642,7 +638,7 @@ impl Process<Nftables> for ContainerToHostRule {
                       "network" => format!("{:?}", network)));
 
         let network_id = network.id.as_ref().expect("Docker network ID missing");
-        let bridge_name = get_bridge_name(network_id)?;
+        let bridge_name = get_bridge_name(network)?;
         trace!(ctx.logger, "Got bridge name";
                    o!("network_name" => &network.name,
                       "bridge_name" => &bridge_name));
@@ -821,7 +817,7 @@ impl Process<Nftables> for WiderWorldToContainerRule {
                       "network" => format!("{:?}", network)));
 
             let network_id = network.id.as_ref().expect("Docker network ID missing");
-            let bridge_name = get_bridge_name(network_id)?;
+            let bridge_name = get_bridge_name(network)?;
             trace!(ctx.logger, "Got bridge name";
                    o!("network_name" => &network.name,
                       "bridge_name" => &bridge_name));
@@ -1003,7 +999,7 @@ impl Process<Nftables> for ContainerDNATRule {
                                   "network" => format!("{:?}", network)));
 
                     let network_id = network.id.as_ref().expect("Docker network ID missing");
-                    let bridge_name = get_bridge_name(network_id)?;
+                    let bridge_name = get_bridge_name(network)?;
                     trace!(ctx.logger, "Got bridge name";
                                o!("network_name" => &network.name,
                                   "bridge_name" => &bridge_name));
@@ -1021,7 +1017,7 @@ impl Process<Nftables> for ContainerDNATRule {
                                        o!("network_name" => &network.name,
                                           "src_network" => format!("{:?}", src_network)));
 
-                            let bridge_name = get_bridge_name(network_id)?;
+                            let bridge_name = get_bridge_name(network)?;
                             trace!(ctx.logger, "Got bridge name";
                                        o!("network_name" => &network.name,
                                           "bridge_name" => &bridge_name));
@@ -1057,7 +1053,7 @@ impl Process<Nftables> for ContainerDNATRule {
                        o!("network_name" => &network.name,
                           "dst_network" => format!("{:?}", dst_network)));
 
-            let bridge_name = get_bridge_name(network_id)?;
+            let bridge_name = get_bridge_name(network)?;
             trace!(ctx.logger, "Got bridge name";
                        o!("network_name" => &network.name,
                           "bridge_name" => &bridge_name));

--- a/src/process.rs
+++ b/src/process.rs
@@ -215,11 +215,17 @@ impl Default for ProcessingOptions {
     }
 }
 
-pub(crate) fn get_bridge_name(network_id: &str) -> Result<String> {
-    if network_id.len() < 12 {
-        bail!("network has to be longer than 12 characters");
-    }
-    Ok(format!("br-{}", &network_id[..12]))
+pub(crate) fn get_bridge_name(network: &Network) -> Result<String> {
+    return network.options.as_ref()
+        .and_then(|options| options.get("com.docker.network.bridge.name"))
+        .map(|value| Ok(value.to_owned()))
+        .unwrap_or_else(|| {
+            let network_id = network.id.as_ref().expect("Docker network ID missing");
+            if network_id.len() < 12 {
+                bail!("network has to be longer than 12 characters");
+            }
+            return Ok(format!("br-{}", &network_id[..12]));
+        });
 }
 
 pub(crate) fn get_network_for_container(


### PR DESCRIPTION
I added support for custom bridge interface names by using the value of the `com.docker.network.bridge.name` driver option if it is available.